### PR TITLE
Fix scheduler shutdown error and remove settings menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       "functions/**/*",
       "shared/**/*",
       "data/**/*",
-      "node_modules/**/*"
+      "node_modules/**/*",
+      ".env"
     ],
     "mac": {
       "icon": "assets/icon.icns",

--- a/src/main.js
+++ b/src/main.js
@@ -110,10 +110,6 @@ class Runner {
         click: () => this.reloadFunctions()
       },
       {
-        label: 'Settings',
-        click: () => this.openSettings()
-      },
-      {
         label: 'Quit',
         click: () => {
           this.shutdown();
@@ -146,11 +142,6 @@ class Runner {
     }
   }
 
-  openSettings() {
-    console.log('Opening settings...');
-    // TODO: Implement settings window
-    this.notificationManager.showInfo('Settings', 'Settings window not implemented yet');
-  }
 
   shutdown() {
     console.log('Shutting down Runner...');

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -23,7 +23,7 @@ class Scheduler {
   stop() {
     console.log('Stopping scheduler...');
     this.scheduledTasks.forEach(task => {
-      task.destroy();
+      task.stop();
     });
     this.scheduledTasks.clear();
   }


### PR DESCRIPTION
## Summary
- Fix scheduler shutdown error by using `task.stop()` instead of `task.destroy()` for node-cron tasks
- Remove unused Settings menu item and `openSettings()` method from menu bar
- Add `.env` file to build configuration so environment variables are included in DMG

## Test plan
- [x] Verify app shuts down properly without crashing
- [x] Confirm Settings menu item is removed from menu bar
- [x] Test that environment variables are available in built DMG
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)